### PR TITLE
Add support for specifying postcss executable path

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -4,7 +4,7 @@
 
 (task-options!
  pom {:project 'danielsz/boot-autoprefixer
-      :version "0.0.8"
+      :version "0.0.9"
       :scm {:name "git"
             :url "https://github.com/danielsz/boot-autoprefixer"}})
 
@@ -17,6 +17,3 @@
   (comp
    (build)
    (push :repo "clojars")))
-
-
-

--- a/src/danielsz/autoprefixer.clj
+++ b/src/danielsz/autoprefixer.clj
@@ -14,17 +14,18 @@
        (map (juxt core/tmp-path core/tmp-file identity))))
 
 (core/deftask autoprefixer
-  [f files    FILES       [str] "A vector of filenames to process with autoprefixer."
-
-   b browsers BROWSERS    str   "A string describing browsers autoprefixer will target.
+  [p exec-path PATH        str   "PostCSS executable path (defaults to \"postcss\" if omitted)."
+   f files     FILES       [str] "A vector of filenames to process with autoprefixer."
+   b browsers  BROWSERS    str   "A string describing browsers autoprefixer will target.
    Eg:  \"last 1 version, > 5%\".
    More details at https://github.com/ai/browserslist"]
   (let [tmp-dir (core/tmp-dir!)]
     (core/with-pre-wrap fileset
       (doseq [[in-path in-file file] (find-css-files fileset files)]
         (boot.util/info "Autoprefixing %s\n" (:path file))
-        (let [out-file (doto (io/file tmp-dir in-path) io/make-parents)]
-          (apply util/dosh "postcss" "--use" "autoprefixer"
+        (let [out-file (doto (io/file tmp-dir in-path) io/make-parents)
+              postcss (or exec-path "postcss")]
+          (apply util/dosh postcss "--use" "autoprefixer"
                  (.getPath in-file)
                  "-o" (.getPath out-file)
                  (when browsers ["--autoprefixer.browsers" browsers]))))


### PR DESCRIPTION
This is useful if you don't want to install postcss globally.