### PR TITLE
Make the in-file argument unambiguous

### DIFF
--- a/src/danielsz/autoprefixer.clj
+++ b/src/danielsz/autoprefixer.clj
@@ -24,11 +24,12 @@
       (doseq [[in-path in-file file] (find-css-files fileset files)]
         (boot.util/info "Autoprefixing %s\n" (:path file))
         (let [out-file (doto (io/file tmp-dir in-path) io/make-parents)
-              postcss (or exec-path "postcss")]
+              postcss (or exec-path "postcss")
+              args    (if browsers ["--autoprefixer.browsers" browsers] [])
+              args    (into args ["--" (.getPath in-file)])]
           (apply util/dosh postcss "--use" "autoprefixer"
-                 (.getPath in-file)
                  "-o" (.getPath out-file)
-                 (when browsers ["--autoprefixer.browsers" browsers]))))
+                 args)))
       (-> fileset
           (core/add-resource tmp-dir)
           core/commit!))))


### PR DESCRIPTION
Closes #9.

Tested changes with both 2.6.0 and 3.0.0-beta versions of postcss-cli locally.